### PR TITLE
修复download()的字符串拼接错误

### DIFF
--- a/vps2arch
+++ b/vps2arch
@@ -45,7 +45,7 @@ download() {
 	local path="$1" x=
 	shift
 	for x in $mirrors; do
-		_download "$x/$path" && return 0
+		_download "$x$path" && return 0
 	done
 	return 1
 }


### PR DESCRIPTION
get_mirrors()获取的链接末尾本身是有 “/”的，所以最后拼接的时候会变成双斜杠
![image](https://user-images.githubusercontent.com/10690839/93845804-c238f380-fcd4-11ea-8304-fdef464e0b7f.png)
