### PR TITLE
fix: Remove useless lines in checksum

### DIFF
--- a/vps2arch
+++ b/vps2arch
@@ -52,7 +52,7 @@ download() {
 
 download_and_extract_bootstrap() {
 	local sha1 filename
-	download iso/latest/sha1sums.txt | fgrep "$cpu_type.tar.gz" > "sha1sums.txt"
+	download iso/latest/sha1sums.txt | egrep "[[:digit:]]-$cpu_type.tar.gz" > "sha1sums.txt"
 	read -r sha1 filename < "sha1sums.txt"
 	download "iso/latest/$filename" > "$filename"
 	sha1sum -c sha1sums.txt || exit 1


### PR DESCRIPTION
Due to `sha1sum.txt` file structure change

From:
```plain
f0e9a794dbbc2f593389100273a3714d46c5cecf  archlinux-2021.03.01-x86_64.iso
195c4464d004267947921e73baf6846ecf9f3c1e  archlinux-bootstrap-2021.03.01-x86_64.tar.gz
```

To:
```plain
42138726a0c439cec40b4d52c9e03601d61b4cd3  archlinux-2022.07.01-x86_64.iso
42138726a0c439cec40b4d52c9e03601d61b4cd3  archlinux-x86_64.iso
a7cf82894083d43879658046646303c31a453f7e  archlinux-bootstrap-2022.07.01-x86_64.tar.gz
a7cf82894083d43879658046646303c31a453f7e  archlinux-bootstrap-x86_64.tar.gz
```

This change results in `sha1sum` trying to check `archlinux-bootstrap-x86_64.tar.gz` which doesn't exist, causing error.

Log:
```plain
# ./vps2arch 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   335  100   335    0     0    471      0 --:--:-- --:--:-- --:--:--   471
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    198      0 --:--:-- --:--:-- --:--:--   198
100   493  100   493    0     0    297      0  0:00:01  0:00:01 --:--:-- 14085
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   300  100   300    0     0  14035      0 --:--:-- --:--:-- --:--:-- 14285
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  159M  100  159M    0     0   291M      0 --:--:-- --:--:-- --:--:--  291M
archlinux-bootstrap-2022.07.01-x86_64.tar.gz: OK
sha1sum: archlinux-bootstrap-x86_64.tar.gz: No such file or directory
archlinux-bootstrap-x86_64.tar.gz: FAILED open or read
sha1sum: WARNING: 1 listed file could not be read
```